### PR TITLE
Help & Exit Testcase

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1,4 +1,52 @@
+#include <iostream>
+
+using namespace std;
+
+class iExit
+{
+public:
+	virtual void doExit() = 0;
+private:
+};
+
+class Exit : public iExit
+{
+public:
+	void doExit() override
+	{
+		exit(0);
+	}
+private:
+};
+
 class Shell
 {
 public:
+	Shell() 
+	{
+		_exit = new Exit();
+	};
+
+	void help()
+	{
+		helpMessasge();
+	}
+
+	void helpMessasge()
+	{
+		cout << "This is Help Message" << endl;
+	}
+
+	void exit()
+	{ 
+		_exit->doExit();
+	}
+
+	void setExit(iExit *newExit)
+	{
+		_exit = newExit;
+	}
+private:
+
+	iExit* _exit;
 };

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -6,22 +6,72 @@
 #include <fstream>
 
 #include "../SSD/iSSD.h"
+#include "../Shell/Shell.cpp"
 
 using namespace std;
 using namespace testing;
 
 class SsdMock : public iSSD
 {
+public:
 	MOCK_METHOD(void, write, (int, string), (override));
 	MOCK_METHOD(void, read, (int), (override));
+private:
 };
 
-class ShellTest : public Test
+class ShellTestFixture : public Test
 {
+public:
 	NiceMock<SsdMock> ssdMock{};
+private:
 };
 
-TEST_F(ShellTest, Test)
+class TestableExitActor : public iExit
 {
+public:
+	void doExit() override 
+	{
+		cout << "Tesable Exit" << endl;
+	}
+private:
+};
 
+TEST_F(ShellTestFixture, HelpCallTest)
+{
+	Shell shell;
+	ostringstream redirectedOutput;
+	ostringstream expectedOutput;
+	streambuf* oldCout;
+
+	oldCout = cout.rdbuf(redirectedOutput.rdbuf());
+	shell.help();
+	cout.rdbuf(oldCout);
+
+	oldCout = cout.rdbuf(expectedOutput.rdbuf());
+	shell.helpMessasge();
+	cout.rdbuf(oldCout);
+
+	EXPECT_EQ(redirectedOutput.str(), expectedOutput.str());
+}
+
+TEST_F(ShellTestFixture, DISABLE_ExitCallTest)
+{
+	Shell shell;
+	TestableExitActor testableExitActor;
+
+	ostringstream redirectedOutput;
+	ostringstream expectedOutput;
+	streambuf* oldCout;
+
+	shell.setExit(&testableExitActor);
+
+	oldCout = cout.rdbuf(redirectedOutput.rdbuf());
+	shell.exit();
+	cout.rdbuf(oldCout);
+
+	oldCout = cout.rdbuf(expectedOutput.rdbuf());
+	testableExitActor.doExit();
+	cout.rdbuf(oldCout);
+
+	EXPECT_EQ(redirectedOutput.str(), expectedOutput.str());
 }


### PR DESCRIPTION
1. Add Help & Exit TestCase
- Help Message는 일단 임시 구현이며, Help Method와 Help Message 분리하여 Expect Test 가능하도록 했습니다.
2. Testable Exit
- Exit 시 실제로 exit(0)을 실행하여 종료 시 아래 테스트들이 수행되지 않아, Testable Exit 방식으로 구현했습니다. 