### PR TITLE
Feature/shell enable full read write

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -90,22 +90,24 @@ public:
 		return "0x00000000";
 	}
 
-	void write(unsigned int lba, const string& data)
+	void write(unsigned int lba, const string& inputData)
 	{
 		if (verifyLba(lba)) return;
-		if (verifyDataFormat(data)) return;
-		string arguments = "W " + to_string(lba) + " " + data + "\n";
-		m_ssdExcutable->execute(arguments);
-	}
-
-	void fullwrite(const string inputData)
-	{
+		if (verifyDataFormat(inputData)) return;
 		if (false == IsInputDataWithPrefix(inputData))	return;
 		if (false == IsInputDataWithValidRange(inputData)) return;
 
+		string arguments = "W " + to_string(lba) + " " + inputData + "\n";
+		m_ssdExcutable->execute(arguments);
+	}
+
+	void fullwrite(const string& inputData)
+	{
+		if (false == IsInputDataWithPrefix(inputData))	return;
+		if (false == IsInputDataWithValidRange(inputData)) return;
 		for (int iter = 0; iter < 100; iter++)
 		{
-			m_ssd->write(iter, inputData);
+			write(iter, inputData);
 		}
 	}
 
@@ -113,7 +115,7 @@ public:
 	{
 		for (int iter = 0; iter < 100; iter++)
 		{
-			m_ssd->read(iter);
+			read(iter);
 		}
 	}
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -134,6 +134,10 @@ private:
 
 	bool verifyDataFormat(const std::string& data)
 	{
+		if (data.size() != 10)
+		{
+			m_outputStream << "[WARNING] Invalid input data length !!!" << endl;
+		}
 		return data.size() != 10;
 	}
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -27,17 +27,19 @@ class Shell
 {
 public:
 
-	Shell(void) 
+	Shell(void) : m_outputStream(cout)
 	{
 		_exit = new Exit();
 	}
 
-	Shell(iSSD* ssd) : m_ssd(ssd)
+	Shell(iSSD* ssd) : m_ssd(ssd), m_outputStream(cout)
 	{
 		_exit = new Exit();
 	}
 
-	Shell(ISsdExecutable* executable) : m_ssdExcutable(executable)
+	Shell(ISsdExecutable* executable, ostream& _out) :
+		m_ssdExcutable(executable),
+		m_outputStream(_out)
 	{
 		_exit = new Exit();
 	}
@@ -48,7 +50,7 @@ public:
 
 	void helpMessasge()
 	{
-		cout << "This is Help Message" << endl;
+		m_outputStream << "This is Help Message" << endl;
 	}
 
 	void exit()
@@ -66,9 +68,9 @@ public:
 		string userInput;
 		while (true)
 		{
-			cout << "shell> ";
+			m_outputStream << "shell> ";
 			getline(inputStream, userInput);
-			cout << userInput << endl;
+			m_outputStream << userInput << endl;
 			if (userInput == "exit")
 			{
 				exit();
@@ -123,6 +125,7 @@ private:
 	iSSD* m_ssd{};
 	iExit* _exit;
 	ISsdExecutable* m_ssdExcutable{};
+	ostream& m_outputStream;
 
 	bool verifyLba(unsigned int lba)
 	{
@@ -138,7 +141,7 @@ private:
 	{
 		if (inputData[0] != '0' || inputData[1] != 'x')
 		{
-			cout << "[WARNING] Prefix '0x' was not included in input data !!!" << endl;
+			m_outputStream << "[WARNING] Prefix '0x' was not included in input data !!!" << endl;
 			return false;
 		}
 
@@ -154,7 +157,7 @@ private:
 				continue;
 			}
 
-			cout << "[WARNING] Input data has invalid characters !!!" << endl;
+			m_outputStream << "[WARNING] Input data has invalid characters !!!" << endl;
 			return false;
 		}
 

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -52,6 +52,14 @@ protected:
 		return fetchedString;
 	}
 
+	void writeAndExpect(string input, string expected)
+	{
+		shell.write(VALID_LBA, input);
+
+		EXPECT_THAT(fetchOutput(), expected);
+	}
+
+private:
 	ostringstream redirectedOutput{};
 };
 
@@ -103,18 +111,10 @@ TEST_F(ShellTestFixture, OutOfLbaWrite)
 TEST_F(ShellTestFixture, InvalidDataFormatWrite)
 {
 	EXPECT_CALL(ssdExecutableMock, execute(_)).Times(0);
-	shell.write(VALID_LBA, "0x0");
-	EXPECT_THAT(fetchOutput(), Eq(""));
 
-	shell.write(VALID_LBA, "abcd123456");
-
-	string expected = "[WARNING] Prefix '0x' was not included in input data !!!\n";
-	EXPECT_THAT(fetchOutput(), Eq(expected));
-
-	shell.write(VALID_LBA, "0xabcd1234");
-
-	expected = "[WARNING] Input data has invalid characters !!!\n";
-	EXPECT_THAT(fetchOutput(), Eq(expected));
+	writeAndExpect("0x0", "[WARNING] Invalid input data length !!!\n");
+	writeAndExpect("abcd123456", "[WARNING] Prefix '0x' was not included in input data !!!\n");
+	writeAndExpect("0xabcd1234", "[WARNING] Input data has invalid characters !!!\n");
 }
 
 TEST_F(ShellTestFixture, WriteSuccess)


### PR DESCRIPTION
fullread fullwrite TC를 다시 enable 하였습니다.
Test 코드를 refactoring 하여 반복해서 input output stream 을 redirect 하지 않아도 되도록 하였고, 
쉽게 stream buffer의 값을 가져오고, clear 할 수 있는 helper function을 추가하였습니다.