### PR TITLE
Feature/shell testapp1

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -126,7 +126,18 @@ public:
 		fullwrite("0xDEADC0DE");
 		fullread();
 
-		bool isDifferentData = true;
+        string referenceData = "";
+        for (int i = 0; i < 100; i++)
+        {
+            referenceData += "0xDEADC0DE";
+        }
+
+        ostringstream* redirectedOutput = dynamic_cast<ostringstream*>(&m_outputStream);
+        string readData = redirectedOutput->str();
+        redirectedOutput->str("");
+        redirectedOutput->clear();
+
+		bool isDifferentData = (referenceData != readData);
 
 		if (isDifferentData)
 		{

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -125,7 +125,16 @@ public:
 	{
 		fullwrite("0xDEADC0DE");
 		fullread();
-		cout << "[WARNING] testapp1 : written data is different with read data!!!" << endl;
+
+		bool isDifferentData = true;
+
+		if (isDifferentData)
+		{
+			m_outputStream << "[WARNING] testapp1 : written data is different with read data!!!" << endl;
+			return;
+		}
+
+		m_outputStream << "testapp1 : Done test, written data is same with read data :)" << endl;
 	}
 
 private:

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -126,8 +126,21 @@ public:
 		fullwrite("0xDEADC0DE");
 		fullread();
 
+		bool isCompareSuccess = readCompare();
+
+		if (false == isCompareSuccess)
+		{
+			m_outputStream << "[WARNING] testapp1 : written data is different with read data!!!" << endl;
+			return;
+		}
+
+		m_outputStream << "testapp1 : Done test, written data is same with read data :)" << endl;
+	}
+
+    bool readCompare()
+    {
         string referenceData = "";
-        for (int i = 0; i < 100; i++)
+        for (int iter = 0; iter < 100; iter++)
         {
             referenceData += "0xDEADC0DE";
         }
@@ -137,16 +150,8 @@ public:
         redirectedOutput->str("");
         redirectedOutput->clear();
 
-		bool isDifferentData = (referenceData != readData);
-
-		if (isDifferentData)
-		{
-			m_outputStream << "[WARNING] testapp1 : written data is different with read data!!!" << endl;
-			return;
-		}
-
-		m_outputStream << "testapp1 : Done test, written data is same with read data :)" << endl;
-	}
+        return (referenceData == readData);
+    }
 
 private:
     iExit* _exit;

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -117,6 +117,13 @@ public:
 		}
 	}
 
+	void doTestApp1()
+	{
+		fullwrite("0xDEADC0DE");
+		fullread();
+		cout << "[WARNING] testapp1 : written data is different with read data!!!" << endl;
+	}
+
 private:
 	iSSD* m_ssd{};
 	iExit* _exit;

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -193,17 +193,23 @@ TEST_F(ShellTestFixture, TestApp1FailureCase)
     string expected = "[WARNING] testapp1 : written data is different with read data!!!\n";
 
     EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
+    EXPECT_CALL(ssdResultMock, get())
+        .WillOnce(Return("0xDEADC0DE"))
+        .WillOnce(Return("0xDEADC0DE"))
+        .WillOnce(Return("0xDEADC0DE"))
+        .WillRepeatedly(Return(dataZero));
 
     shell.doTestApp1();
 
     EXPECT_THAT(fetchOutput(), Eq(expected));
 }
 
-TEST_F(ShellTestFixture, DISABLED_TestApp1SuccessCase)
+TEST_F(ShellTestFixture, TestApp1SuccessCase)
 {
     string expected = "testapp1 : Done test, written data is same with read data :)\n";
 
     EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
+    EXPECT_CALL(ssdResultMock, get()).WillRepeatedly(Return("0xDEADC0DE"));
 
     shell.doTestApp1();
 

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -47,6 +47,7 @@ protected:
     static constexpr int INVALID_LBA = 100;
     static constexpr int VALID_LBA = 99;
     const string dataZero = "0x00000000";
+    const string testData = "0xDEADC0DE";
 
     void SetUp(void) override
     {
@@ -194,9 +195,9 @@ TEST_F(ShellTestFixture, TestApp1FailureCase)
 
     EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
     EXPECT_CALL(ssdResultMock, get())
-        .WillOnce(Return("0xDEADC0DE"))
-        .WillOnce(Return("0xDEADC0DE"))
-        .WillOnce(Return("0xDEADC0DE"))
+        .WillOnce(Return(testData))
+        .WillOnce(Return(testData))
+        .WillOnce(Return(testData))
         .WillRepeatedly(Return(dataZero));
 
     shell.doTestApp1();
@@ -209,7 +210,7 @@ TEST_F(ShellTestFixture, TestApp1SuccessCase)
     string expected = "testapp1 : Done test, written data is same with read data :)\n";
 
     EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
-    EXPECT_CALL(ssdResultMock, get()).WillRepeatedly(Return("0xDEADC0DE"));
+    EXPECT_CALL(ssdResultMock, get()).WillRepeatedly(Return(testData));
 
     shell.doTestApp1();
 

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -193,3 +193,33 @@ TEST_F(ShellTestFixture, RunAndRead)
 	
 	// should check result
 }
+
+TEST_F(ShellTestFixture, DISABLED_TestApp1FailureCase)
+{
+	string expected = "[WARNING] testapp1 : written data is different with read data!!!\n";
+	ostringstream redirectedOutput;
+	streambuf* coutBuf;
+	
+	EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
+
+	coutBuf = cout.rdbuf(redirectedOutput.rdbuf());
+	shell.doTestApp1();
+	cout.rdbuf(coutBuf);
+
+	EXPECT_THAT(redirectedOutput.str(), Eq(expected));
+}
+
+TEST_F(ShellTestFixture, DISABLED_TestApp1SuccessCase)
+{
+	string expected = "testapp1 : Done test, written data is same with read data :)\n";
+	ostringstream redirectedOutput;
+	streambuf* coutBuf;
+
+	EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
+
+	coutBuf = cout.rdbuf(redirectedOutput.rdbuf());
+	shell.doTestApp1();
+	cout.rdbuf(coutBuf);
+
+	EXPECT_THAT(redirectedOutput.str(), Eq(expected));
+}

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -175,32 +175,24 @@ TEST_F(ShellTestFixture, RunAndRead)
 	// should check result
 }
 
-TEST_F(ShellTestFixture, DISABLED_TestApp1FailureCase)
+TEST_F(ShellTestFixture, TestApp1FailureCase)
 {
 	string expected = "[WARNING] testapp1 : written data is different with read data!!!\n";
-	ostringstream redirectedOutput;
-	streambuf* coutBuf;
 	
 	EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
 
-	coutBuf = cout.rdbuf(redirectedOutput.rdbuf());
 	shell.doTestApp1();
-	cout.rdbuf(coutBuf);
 
-	EXPECT_THAT(redirectedOutput.str(), Eq(expected));
+	EXPECT_THAT(fetchOutput(), Eq(expected));
 }
 
 TEST_F(ShellTestFixture, DISABLED_TestApp1SuccessCase)
 {
 	string expected = "testapp1 : Done test, written data is same with read data :)\n";
-	ostringstream redirectedOutput;
-	streambuf* coutBuf;
 
 	EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
 
-	coutBuf = cout.rdbuf(redirectedOutput.rdbuf());
 	shell.doTestApp1();
-	cout.rdbuf(coutBuf);
 
-	EXPECT_THAT(redirectedOutput.str(), Eq(expected));
+	EXPECT_THAT(fetchOutput(), Eq(expected));
 }


### PR DESCRIPTION
test script 중 testapp1 개발 진행

- Test case
  > testapp1 script 도중 fullread와 fullwrite의 data가 맞지 않은 경우
  > testapp1 scirpt에서 fullread와 fullwrite의 data가 모두 일치하는 경우

- fullwrite에서 input한 data 100개를 나열한 string을 reference로 지정 후
- fullread에서 stream buffer에 저장해둔 데이터를 string type으로 변경하여 reference data와 비교
- 일치하는 경우 : "testapp1 : Done test, written data is same with read data :)\n" 문자열을 출력 (EXPECT_EQ로 비교)
- 일치하지 않는 경우 : "[WARNING] testapp1 : written data is different with read data!!!\n" 문자열을 출력 (EXPECT_EQ로 비교)