### PR TITLE
Feature/shell testapp2

### DIFF
--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -144,7 +144,7 @@ public:
 		fullwrite("0xDEADC0DE");
 		fullread();
 
-		bool isCompareSuccess = readCompare();
+		bool isCompareSuccess = readCompare(100, "0xDEADC0DE");
 
 		if (false == isCompareSuccess)
 		{
@@ -155,20 +155,40 @@ public:
 		m_outputStream << "testapp1 : Done test, written data is same with read data :)" << endl;
 	}
 
-    bool readCompare()
+    void doTestApp2()
     {
-        string referenceData = "";
-        for (int iter = 0; iter < 100; iter++)
+        for (int i = 0; i < 30; i++)
         {
-            referenceData += "0xDEADC0DE";
+            write(0, "0xAAAABBBB");
+            write(1, "0xAAAABBBB");
+            write(2, "0xAAAABBBB");
+            write(3, "0xAAAABBBB");
+            write(4, "0xAAAABBBB");
+            write(5, "0xAAAABBBB");
         }
 
-        ostringstream* redirectedOutput = dynamic_cast<ostringstream*>(&m_outputStream);
-        string readData = redirectedOutput->str();
-        redirectedOutput->str("");
-        redirectedOutput->clear();
+        write(0, "0x12345678");
+        write(1, "0x12345678");
+        write(2, "0x12345678");
+        write(3, "0x12345678");
+        write(4, "0x12345678");
+        write(5, "0x12345678");
+        
+        read(0);
+        read(1);
+        read(2);
+        read(3);
+        read(4);
+        read(5);
 
-        return (referenceData == readData);
+        bool isCompareSuccess = readCompare(6, "0x12345678");
+
+        if (false == isCompareSuccess)
+        {
+            m_outputStream << "[WARNING] testapp2 : written data is different with read data!!!" << endl;
+            return;
+        }
+        m_outputStream << "testapp2 : Done test, written data is same with read data :)" << endl;
     }
 
 private:
@@ -216,5 +236,21 @@ private:
         }
 
         return true;
+    }
+
+    bool readCompare(const int lbaBound, const string& inputData)
+    {
+        string referenceData = "";
+        for (int iter = 0; iter < lbaBound; iter++)
+        {
+            referenceData += inputData;
+        }
+
+        ostringstream* redirectedOutput = dynamic_cast<ostringstream*>(&m_outputStream);
+        string readData = redirectedOutput->str();
+        redirectedOutput->str("");
+        redirectedOutput->clear();
+
+        return (referenceData == readData);
     }
 };

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -144,7 +144,7 @@ public:
 		fullwrite("0xDEADC0DE");
 		fullread();
 
-		bool isCompareSuccess = readCompare(100, "0xDEADC0DE");
+		bool isCompareSuccess = readCompare("0xDEADC0DE", 100);
 
 		if (false == isCompareSuccess)
 		{
@@ -157,31 +157,17 @@ public:
 
     void doTestApp2()
     {
+        unsigned int lbaBound = 6;
+
         for (int i = 0; i < 30; i++)
         {
-            write(0, "0xAAAABBBB");
-            write(1, "0xAAAABBBB");
-            write(2, "0xAAAABBBB");
-            write(3, "0xAAAABBBB");
-            write(4, "0xAAAABBBB");
-            write(5, "0xAAAABBBB");
+            writeRepeatedly("0xAAAABBBB", lbaBound);
         }
 
-        write(0, "0x12345678");
-        write(1, "0x12345678");
-        write(2, "0x12345678");
-        write(3, "0x12345678");
-        write(4, "0x12345678");
-        write(5, "0x12345678");
-        
-        read(0);
-        read(1);
-        read(2);
-        read(3);
-        read(4);
-        read(5);
+        writeRepeatedly("0x12345678", lbaBound);
+        readRepeatedly(lbaBound);
 
-        bool isCompareSuccess = readCompare(6, "0x12345678");
+        bool isCompareSuccess = readCompare("0x12345678", lbaBound);
 
         if (false == isCompareSuccess)
         {
@@ -238,7 +224,7 @@ private:
         return true;
     }
 
-    bool readCompare(const int lbaBound, const string& inputData)
+    bool readCompare(const string& inputData, unsigned int lbaBound)
     {
         string referenceData = "";
         for (int iter = 0; iter < lbaBound; iter++)
@@ -252,5 +238,21 @@ private:
         redirectedOutput->clear();
 
         return (referenceData == readData);
+    }
+
+    void readRepeatedly(const int lbaBound)
+    {
+        for (int lbaIter = 0; lbaIter < lbaBound; lbaIter++)
+        {
+            read(lbaIter);
+        }
+    }
+
+    void writeRepeatedly(const string& inputData, const int lbaBound)
+    {
+        for (int lbaIter = 0; lbaIter < lbaBound; lbaIter++)
+        {
+            write(lbaIter, inputData);
+        }
     }
 };

--- a/Shell_Test/test.cpp
+++ b/Shell_Test/test.cpp
@@ -247,3 +247,27 @@ TEST_F(ShellTestFixture, TestApp1SuccessCase)
 
     EXPECT_THAT(fetchOutput(), Eq(expected));
 }
+
+TEST_F(ShellTestFixture, TestApp2FailureCase)
+{
+    string expected = "[WARNING] testapp2 : written data is different with read data!!!\n";
+
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(192);
+    EXPECT_CALL(ssdResultMock, get()).WillRepeatedly(Return("0xAAAABBBB"));
+
+    shell.doTestApp2();
+
+    EXPECT_THAT(fetchOutput(), Eq(expected));
+}
+
+TEST_F(ShellTestFixture, TestApp2SuccessCase)
+{
+    string expected = "testapp2 : Done test, written data is same with read data :)\n";
+
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(192);
+    EXPECT_CALL(ssdResultMock, get()).WillRepeatedly(Return("0x12345678"));
+
+    shell.doTestApp2();
+
+    EXPECT_THAT(fetchOutput(), Eq(expected));
+}


### PR DESCRIPTION
test script 중 testapp2 개발 진행

Test case
  > testapp2 script 진행 후 예상되는 data와 read로 읽은 data가 일치하지 않는 경우
  > testapp2 script 진행 후 예상되는 data와 read로 읽은 data가 일치하는 경우

script 순서
1. 0 ~ 5번 lba에 "0xAAAABBBB" 값을 입력 (30회 반복)
2. 0 ~ 5번 lba에 "0x12345678" 값을 입력 (1회)
3. 0 ~ 5번 lba 값을 read
4. read를 통해 stream buffer에 저장해둔 데이터를 string type으로 변경하여 reference data와 비교
(reference data : 0x12345678이 6회 반복된 string 값)

일치하는 경우 : "testapp2 : Done test, written data is same with read data :)\n" 문자열을 출력 (EXPECT_EQ로 비교)

일치하지 않는 경우 : "[WARNING] testapp2 : written data is different with read data!!!\n" 문자열을 출력 (EXPECT_EQ로 비교)