### PR TITLE
Feature/shell fix logger

### DIFF
--- a/Shell/CommandHandler.h
+++ b/Shell/CommandHandler.h
@@ -49,5 +49,5 @@ protected:
 
 	std::ostream& m_outputStream;
 	SsdHelper& m_ssdHelper;
-	Logger logger;
+	Logger& logger = Logger::getInstance();
 };

--- a/Shell/Exit.cpp
+++ b/Shell/Exit.cpp
@@ -7,10 +7,14 @@ bool Exit::isValidArgs(const vector<string>& args)
 
     return VALID;
 }
-
+#include <chrono>
+#include <thread>
 Progress Exit::doCommand(const vector<string>& args)
 {
     m_outputStream << "Exit from Shell" << endl;
     logger.print("Command : " + sliceString(args, 0));
+    logger.clean();
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     return Progress::Done;
 }

--- a/Shell/Logger.cpp
+++ b/Shell/Logger.cpp
@@ -72,7 +72,7 @@ long long Logger::getFileSize(const std::string& filename)
 	return file.tellg();
 }
 
-std::string& Logger::getSaveFileName()
+std::string Logger::getSaveFileName()
 {
 	std::string result = "until_" + getCurrentTimeFileFormatted() + ".log";
 
@@ -125,10 +125,10 @@ void Logger::doZip()
 	{
 		return;
 	}
+
 	std::string oldFileName = logFileQueue.front();
 	std::string newFileName = oldFileName;
 	size_t dotIndex = newFileName.find_last_of('.');
-	std::cout << "Dozip : " << oldFileName << std::endl;
 	if (dotIndex != std::string::npos)
 	{
 		newFileName.replace(dotIndex, newFileName.size() - dotIndex, ".zip");
@@ -141,11 +141,8 @@ void Logger::doZip()
 
 void Logger::clean()
 {
-	std::cout << "Cleanup : " << logFileQueue.size() << std::endl;
-
 	while (!logFileQueue.empty())
 	{
-		std::cout << "????" << std::endl;
 		doZip();
 	}
 }

--- a/Shell/Logger.cpp
+++ b/Shell/Logger.cpp
@@ -72,7 +72,7 @@ long long Logger::getFileSize(const std::string& filename)
 	return file.tellg();
 }
 
-std::string Logger::getSaveFileName()
+std::string& Logger::getSaveFileName()
 {
 	std::string result = "until_" + getCurrentTimeFileFormatted() + ".log";
 
@@ -107,10 +107,13 @@ void Logger::agingLogFile()
 			if (changeFileName(oldFileName, newFileName))
 			{
 				logFileQueue.push(newFileName);
+
+				std::cout << "Enqueue!!! : " << newFileName << " : " << logFileQueue.size() << std::endl;
 				if (logFileQueue.size() == 2)
 				{
 					doZip();
 				}
+				std::cout << "Enqueue and...!!! : " << newFileName << " : " << logFileQueue.size() << std::endl;
 			}
 		}
 	}
@@ -118,9 +121,14 @@ void Logger::agingLogFile()
 
 void Logger::doZip()
 {
+	if (logFileQueue.empty())
+	{
+		return;
+	}
 	std::string oldFileName = logFileQueue.front();
 	std::string newFileName = oldFileName;
 	size_t dotIndex = newFileName.find_last_of('.');
+	std::cout << "Dozip : " << oldFileName << std::endl;
 	if (dotIndex != std::string::npos)
 	{
 		newFileName.replace(dotIndex, newFileName.size() - dotIndex, ".zip");
@@ -128,5 +136,16 @@ void Logger::doZip()
 	if (changeFileName(oldFileName, newFileName))
 	{
 		logFileQueue.pop();
+	}
+}
+
+void Logger::clean()
+{
+	std::cout << "Cleanup : " << logFileQueue.size() << std::endl;
+
+	while (!logFileQueue.empty())
+	{
+		std::cout << "????" << std::endl;
+		doZip();
 	}
 }

--- a/Shell/Logger.h
+++ b/Shell/Logger.h
@@ -8,7 +8,14 @@
 class Logger
 {
 public:
-	Logger() { };
+	static Logger& getInstance()
+	{
+		static Logger instance{};
+		return instance;
+	}
+	Logger() {};
+	Logger& operator=(const Logger& other) = delete;
+	Logger(const Logger& other) = delete;
 
 	void print(std::string msg, const std::source_location& caller = std::source_location::current());
 	void clean();
@@ -21,7 +28,7 @@ private:
 	std::string extractCallerName(const char* funcSig);
 	std::string formatCallFunction(std::string callFunction);
 	long long getFileSize(const std::string& filename);
-	std::string& getSaveFileName();
+	std::string getSaveFileName();
 	bool changeFileName(std::string from, std::string to);
 	void writeToLogFile(std::string contents);
 	void agingLogFile();

--- a/Shell/Logger.h
+++ b/Shell/Logger.h
@@ -11,6 +11,7 @@ public:
 	Logger() { };
 
 	void print(std::string msg, const std::source_location& caller = std::source_location::current());
+	void clean();
 
 	~Logger() { };
 
@@ -20,7 +21,7 @@ private:
 	std::string extractCallerName(const char* funcSig);
 	std::string formatCallFunction(std::string callFunction);
 	long long getFileSize(const std::string& filename);
-	std::string getSaveFileName();
+	std::string& getSaveFileName();
 	bool changeFileName(std::string from, std::string to);
 	void writeToLogFile(std::string contents);
 	void agingLogFile();


### PR DESCRIPTION
1. 기존 Logger 객체가 command handler마다 생성되어 이상한 동작을 하던 것 발견
(exit, fullread, read 등 command마다 logger 객체가 다 달라서 zip 로직이 제대로 동작하지 않음)
2. 이를 수정하기 위해 Logger 객체를 Singleton으로 수정