### PR TITLE
Feature/shell help

### DIFF
--- a/Shell/CommandFactory.cpp
+++ b/Shell/CommandFactory.cpp
@@ -6,7 +6,6 @@
 #include "FullWrite.h"
 #include "Erase.h"
 #include "EraseRange.h"
-#include "Help.h"
 #include "Exit.h"
 #include "SsdHelper.h"
 
@@ -24,7 +23,6 @@ CommandFactory::CommandFactory(ostream& _out, SsdHelper& _ssd)
 	m_handlers.push_back(new FullWrite(_out, _ssd, writeObject));
 	m_handlers.push_back(new Erase(_out, _ssd));
 	m_handlers.push_back(new EraseRange(_out, _ssd));
-	m_handlers.push_back(new Help(_out, _ssd, this));
 	m_handlers.push_back(new Exit(_out, _ssd));
 }
 
@@ -54,8 +52,6 @@ CommandEnum CommandFactory::stringToCommandEnum(const string& commandStr)
 		return CommandEnum::ERASE;
 	if (commandStr == "erase_range")
 		return CommandEnum::ERASE_RANGE;
-	if (commandStr == "help")
-		return CommandEnum::HELP;
 	if (commandStr == "exit")
 		return CommandEnum::EXIT;
 	return CommandEnum::NUMOFCOMMAND;

--- a/Shell/CommandFactory.cpp
+++ b/Shell/CommandFactory.cpp
@@ -24,7 +24,7 @@ CommandFactory::CommandFactory(ostream& _out, SsdHelper& _ssd)
 	m_handlers.push_back(new FullWrite(_out, _ssd, writeObject));
 	m_handlers.push_back(new Erase(_out, _ssd));
 	m_handlers.push_back(new EraseRange(_out, _ssd));
-	m_handlers.push_back(new Help(_out, _ssd));
+	m_handlers.push_back(new Help(_out, _ssd, this));
 	m_handlers.push_back(new Exit(_out, _ssd));
 }
 
@@ -33,6 +33,11 @@ CommandHandler* CommandFactory::create(const string& commandStr)
 	CommandEnum commandEnum = stringToCommandEnum(commandStr);
 	if (commandEnum == CommandEnum::NUMOFCOMMAND) return nullptr;
 	return m_handlers[static_cast<size_t>(commandEnum)];
+}
+
+const std::vector<CommandHandler*>& CommandFactory::getHandlerList(void)
+{
+	return m_handlers;
 }
 
 CommandEnum CommandFactory::stringToCommandEnum(const string& commandStr)

--- a/Shell/CommandFactory.h
+++ b/Shell/CommandFactory.h
@@ -13,7 +13,6 @@ enum class CommandEnum
 	FULLWRITE,
 	ERASE,
 	ERASE_RANGE,
-	HELP,
 	EXIT,
 	NUMOFCOMMAND
 };

--- a/Shell/CommandFactory.h
+++ b/Shell/CommandFactory.h
@@ -24,6 +24,7 @@ public:
 	CommandFactory(std::ostream& _out, SsdHelper& _ssd);
 
 	CommandHandler* create(const std::string& commandStr);
+	const std::vector<CommandHandler*>& getHandlerList(void);
 private:
 	CommandEnum stringToCommandEnum(const std::string& commandStr);
 	std::vector<CommandHandler*> m_handlers{};

--- a/Shell/CommandHandler.h
+++ b/Shell/CommandHandler.h
@@ -23,7 +23,7 @@ public:
 
 	virtual bool isValidArgs(const vector<string>& args) = 0;
 	virtual Progress doCommand(const vector<string>& args) = 0;
-	virtual void usage() = 0;
+	virtual std::string usage() = 0;
 	virtual ~CommandHandler() {};
 private:
 protected:

--- a/Shell/Erase.cpp
+++ b/Shell/Erase.cpp
@@ -19,3 +19,8 @@ Progress Erase::doCommand(const vector<string>& args)
 	m_ssdHelper.execute(arguments);
 	return Progress::Continue;
 }
+
+string Erase::usage() 
+{ 
+	return "erase [START_LBA] [NUMBER_OF_LBA]\n";
+}

--- a/Shell/Erase.h
+++ b/Shell/Erase.h
@@ -12,7 +12,7 @@ public:
 
 	bool isValidArgs(const vector<string>& args) override;
 	Progress doCommand(const vector<string>& args) override;
-	void usage() override {};
+	string usage() override;;
 
 	~Erase() {};
 private:

--- a/Shell/EraseRange.cpp
+++ b/Shell/EraseRange.cpp
@@ -20,3 +20,8 @@ Progress EraseRange::doCommand(const vector<string>& args)
 	m_ssdHelper.execute(arguments);
 	return Progress::Continue;
 }
+
+string EraseRange::usage() 
+{
+	return "erase_range [START_LBA] [END_LBA]\n";
+}

--- a/Shell/EraseRange.h
+++ b/Shell/EraseRange.h
@@ -12,7 +12,7 @@ public:
 
 	bool isValidArgs(const vector<string>& args) override;
 	Progress doCommand(const vector<string>& args) override;
-	void usage() override {};
+	string usage() override;;
 
 	~EraseRange() {};
 private:

--- a/Shell/Exit.cpp
+++ b/Shell/Exit.cpp
@@ -16,3 +16,8 @@ Progress Exit::doCommand(const vector<string>& args)
 
     return Progress::Done;
 }
+
+string Exit::usage()
+{ 
+    return "exit\n";
+}

--- a/Shell/Exit.h
+++ b/Shell/Exit.h
@@ -11,7 +11,7 @@ public:
 
     bool isValidArgs(const vector<string>& args) override;
     Progress doCommand(const vector<string>& args) override;
-    void usage() override {};
+    string usage() override;;
 
     ~Exit() {};
 };

--- a/Shell/FullRead.cpp
+++ b/Shell/FullRead.cpp
@@ -25,7 +25,7 @@ Progress FullRead::doCommand(const vector<string>& args)
 	return Progress::Continue;
 }
 
-void FullRead::usage()
+string FullRead::usage()
 {
-	cout << "fullread" << endl;
+	return "fullread\n";
 }

--- a/Shell/FullRead.h
+++ b/Shell/FullRead.h
@@ -12,7 +12,7 @@ public:
 
 	Progress doCommand(const vector<string>& args) override;
 
-	void usage() override;
+	string usage() override;
 
 	~FullRead() {};
 private:

--- a/Shell/FullWrite.cpp
+++ b/Shell/FullWrite.cpp
@@ -24,3 +24,8 @@ Progress FullWrite::doCommand(const vector<string>& args)
 	}
 	return Progress::Continue;
 }
+
+string FullWrite::usage() 
+{ 
+	return "fullwrite [DATA]\n";
+}

--- a/Shell/FullWrite.h
+++ b/Shell/FullWrite.h
@@ -16,7 +16,7 @@ public:
 
 	Progress doCommand(const vector<string>& args) override;
 
-	void usage() override {}
+	string usage() override;
 
 	~FullWrite() {};
 private:

--- a/Shell/Help.cpp
+++ b/Shell/Help.cpp
@@ -1,23 +1,13 @@
 #include "Help.h"
 
-bool Help::isValidArgs(const vector<string>& args)
-{
-	return VALID;
-}
-
 Progress Help::doCommand(const vector<string>& args)
 {
-	logger.print("Command : " + sliceString(args, 0));
+	logger.print("Command : " "help");
 	m_outputStream << "Help:" << endl;
 	for (auto& command : m_factory->getHandlerList())
 	{
 		m_outputStream << "\t" << command->usage();
 	}
-
+	m_outputStream << "\thelp\n";
 	return Progress::Continue;
-}
-
-string Help::usage()
-{
-	return "help\n";
 }

--- a/Shell/Help.cpp
+++ b/Shell/Help.cpp
@@ -4,9 +4,13 @@ Progress Help::doCommand(const vector<string>& args)
 {
 	logger.print("Command : " "help");
 	m_outputStream << "Help:" << endl;
-	for (auto& command : m_factory->getHandlerList())
+	for (auto& command : m_commandFactory->getHandlerList())
 	{
 		m_outputStream << "\t" << command->usage();
+	}
+	for (auto& script : m_scriptFactory->getCommandList())
+	{
+		m_outputStream << "\t" << m_scriptFactory->create(script, m_ssdHelper)->usage();
 	}
 	m_outputStream << "\thelp\n";
 	return Progress::Continue;

--- a/Shell/Help.cpp
+++ b/Shell/Help.cpp
@@ -8,6 +8,16 @@ bool Help::isValidArgs(const vector<string>& args)
 Progress Help::doCommand(const vector<string>& args)
 {
 	logger.print("Command : " + sliceString(args, 0));
-	m_outputStream << m_helpMessage;
+	m_outputStream << "Help:" << endl;
+	for (auto& command : m_factory->getHandlerList())
+	{
+		m_outputStream << "\t" << command->usage();
+	}
+
 	return Progress::Continue;
+}
+
+string Help::usage()
+{
+	return "help\n";
 }

--- a/Shell/Help.h
+++ b/Shell/Help.h
@@ -1,25 +1,24 @@
 #pragma once
 
 #include "CommandHandler.h"
+#include "CommandFactory.h"
 
 using namespace std;
 
 class Help : public CommandHandler
 {
 public:
-	Help(ostream& _out, SsdHelper& _ssd) : CommandHandler(_out, _ssd) {};
+	Help(ostream& _out, SsdHelper& _ssd, CommandFactory* factory) :
+		CommandHandler(_out, _ssd), m_factory(factory) {};
 
 	bool isValidArgs(const vector<string>& args) override;
 
 	Progress doCommand(const vector<string>& args) override;
 
-	void usage() override {};
+	string usage() override;;
 
 	~Help() {};
 protected:
-	const string m_helpMessage = "Help:\n"
-		"\tread [LBA]\n"
-		"\twrite [LBA] [DATA]\n"
-		"\tfullread\n"
-		"\tfullwrite [DATA]\n";
+
+	CommandFactory* m_factory;
 };

--- a/Shell/Help.h
+++ b/Shell/Help.h
@@ -5,20 +5,18 @@
 
 using namespace std;
 
-class Help : public CommandHandler
+class Help
 {
 public:
-	Help(ostream& _out, SsdHelper& _ssd, CommandFactory* factory) :
-		CommandHandler(_out, _ssd), m_factory(factory) {};
+	Help(ostream& _out, CommandFactory* factory) :
+		m_outputStream(_out),
+		m_factory(factory) {}
 
-	bool isValidArgs(const vector<string>& args) override;
-
-	Progress doCommand(const vector<string>& args) override;
-
-	string usage() override;;
+	Progress doCommand(const vector<string>& args);
 
 	~Help() {};
 protected:
-
+	ostream& m_outputStream;
 	CommandFactory* m_factory;
+	Logger& logger = Logger::getInstance();
 };

--- a/Shell/Help.h
+++ b/Shell/Help.h
@@ -2,21 +2,26 @@
 
 #include "CommandHandler.h"
 #include "CommandFactory.h"
+#include "ScriptFactory.h"
 
 using namespace std;
 
 class Help
 {
 public:
-	Help(ostream& _out, CommandFactory* factory) :
+	Help(ostream& _out, SsdHelper& _ssd, CommandFactory* commandFactory, ScriptFactory* scriptFactory) :
 		m_outputStream(_out),
-		m_factory(factory) {}
+		m_ssdHelper(_ssd),
+		m_commandFactory(commandFactory),
+		m_scriptFactory(scriptFactory) {}
 
 	Progress doCommand(const vector<string>& args);
 
 	~Help() {};
 protected:
 	ostream& m_outputStream;
-	CommandFactory* m_factory;
+	CommandFactory* m_commandFactory;
+	ScriptFactory* m_scriptFactory;
+	SsdHelper& m_ssdHelper;
 	Logger& logger = Logger::getInstance();
 };

--- a/Shell/LbaRangeVerifier.h
+++ b/Shell/LbaRangeVerifier.h
@@ -1,8 +1,19 @@
 #pragma once
 
+#include <string>
+
 class LbaRangeVerifier
 {
 public:
+	bool isInvalidLba(const std::string& lbaString)
+	{
+		for (auto c : lbaString)
+		{
+			if (false == isdigit(c)) return true;
+		}
+		return isLbaOutOfRange(stoi(lbaString));
+	}
+
 	bool isLbaOutOfRange(const int lba)
 	{
 		return lba < 0 || lba > 99;

--- a/Shell/Read.cpp
+++ b/Shell/Read.cpp
@@ -16,6 +16,11 @@ Progress Read::doCommand(const vector<string>& args)
 	return Progress::Continue;
 }
 
+string Read::usage() 
+{
+	return "read [LBA]\n";
+}
+
 bool Read::isInvalidNumberOfArguments(const std::vector<std::string>& args)
 {
 	return (args.size() != 2);

--- a/Shell/Read.cpp
+++ b/Shell/Read.cpp
@@ -3,7 +3,7 @@
 bool Read::isValidArgs(const vector<string>& args)
 {
 	if (isInvalidNumberOfArguments(args)) return INVALID;
-	if (m_lbaRangeVerifier.isLbaOutOfRange(stoi(args[1]))) return INVALID;
+	if (m_lbaRangeVerifier.isInvalidLba(args[1])) return INVALID;
 	return VALID;
 }
 

--- a/Shell/Read.h
+++ b/Shell/Read.h
@@ -14,7 +14,7 @@ public:
 
 	Progress doCommand(const vector<string>& args) override;
 
-	void usage() override {};
+	string usage() override;;
 
 	~Read() {};
 private:

--- a/Shell/ScriptFactory.cpp
+++ b/Shell/ScriptFactory.cpp
@@ -24,6 +24,17 @@ ScriptHandler* ScriptFactory::create(const string& scriptStr, SsdHelper& ssdHelp
 	}
 }
 
+const std::vector<string> ScriptFactory::getCommandList(void)
+{
+	return vector<string> { "testapp1",
+		"testapp2",
+		"testapp3",
+		"testapp4",
+		"testapp5",
+		"testapp6"
+	};
+}
+
 ScriptFactory::ScriptEnum ScriptFactory::CovertStrToScriptEnum(const string& scriptStr)
 {
 	if (scriptStr == "FullWriteAndFullReadAndCompare" || scriptStr == "testapp1")

--- a/Shell/ScriptFactory.h
+++ b/Shell/ScriptFactory.h
@@ -16,6 +16,7 @@ class ScriptFactory
 {
 public:
 	ScriptHandler* create(const string& scriptStr, SsdHelper& ssdHelper);
+	const std::vector<string> getCommandList(void);
 private:
 	typedef enum
 	{

--- a/Shell/ScriptHandler.h
+++ b/Shell/ScriptHandler.h
@@ -12,6 +12,7 @@ public:
     ScriptHandler(ostringstream& stringStream, SsdHelper& ssdHelper);
 
     virtual bool doScript() = 0;
+    virtual string usage() = 0;
     string getScriptResult();
 
 protected:

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -94,7 +94,7 @@ void Shell::parseArguments(istream& inputStream, vector<string>& args)
 
 string Shell::getDirectoryPath(string filePath)
 {
-    size_t lastSlashPos = filePath.find_last_of('/\\');
+    size_t lastSlashPos = filePath.find_last_of(static_cast<char>('/\\'));
     string dirPath = filePath;
     if (lastSlashPos != std::string::npos)
     {

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -1,5 +1,12 @@
 #include "Shell.h"
 
+Shell::Shell(SsdHelper& _ssd, ostream& _out) :
+    m_ssdHelper(_ssd),
+    m_commandFactory(_out, _ssd),
+    m_outputStream(_out),
+    m_help(_out, &m_commandFactory)
+{}
+
 void Shell::run(istream& inputStream)
 {
     while (true)
@@ -16,6 +23,12 @@ void Shell::run(istream& inputStream)
         {
             m_outputStream << args[0] << " " << scriptHandler->getScriptResult() << "\n";
             delete scriptHandler;
+            continue;
+        }
+
+        if (args[0] == "help")
+        {
+            m_help.doCommand(args);
             continue;
         }
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -42,7 +42,7 @@ void Shell::run(istream& inputStream)
         if (!commandHandler->isValidArgs(args))
         {
             m_outputStream << "\nINVALID COMMAND\n";
-            commandHandler->usage();
+            m_outputStream << commandHandler->usage();
             continue;
         }
 

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -8,6 +8,8 @@ void Shell::run(istream& inputStream)
 
         vector<string> args{};
         parseArguments(inputStream, args);
+        
+        if (1 > args.size()) continue;
 
         auto* scriptHandler = m_scriptFactory.create(args[0], m_ssdHelper);
         if (scriptHandler != nullptr)

--- a/Shell/Shell.cpp
+++ b/Shell/Shell.cpp
@@ -4,7 +4,7 @@ Shell::Shell(SsdHelper& _ssd, ostream& _out) :
     m_ssdHelper(_ssd),
     m_commandFactory(_out, _ssd),
     m_outputStream(_out),
-    m_help(_out, &m_commandFactory)
+    m_help(_out, _ssd, &m_commandFactory, &m_scriptFactory)
 {}
 
 void Shell::run(istream& inputStream)

--- a/Shell/Shell.h
+++ b/Shell/Shell.h
@@ -3,7 +3,7 @@
 #include "SsdHelper.h"
 #include "CommandFactory.h"
 #include "ScriptFactory.h"
-
+#include "Help.h"
 #include <iostream>
 #include <vector>
 
@@ -13,11 +13,7 @@ class Shell
 {
 public:
 
-    Shell(SsdHelper& _ssd, ostream& _out) :
-        m_ssdHelper(_ssd),
-        m_commandFactory(_out, _ssd),
-        m_outputStream(_out)
-    {}
+    Shell(SsdHelper& _ssd, ostream& _out);
 
     void run(istream& inputStream);
     void runRunner(const string& fileName);
@@ -28,6 +24,6 @@ private:
     SsdHelper& m_ssdHelper;
     CommandFactory m_commandFactory;
     ScriptFactory m_scriptFactory;
-
+    Help m_help;
     string getDirectoryPath(string filePath);
 };

--- a/Shell/Shell.vcxproj.filters
+++ b/Shell/Shell.vcxproj.filters
@@ -22,9 +22,6 @@
     <ClCompile Include="FullWrite.cpp">
       <Filter>소스 파일\Command</Filter>
     </ClCompile>
-    <ClCompile Include="Help.cpp">
-      <Filter>소스 파일\Command</Filter>
-    </ClCompile>
     <ClCompile Include="Read.cpp">
       <Filter>소스 파일\Command</Filter>
     </ClCompile>
@@ -60,6 +57,9 @@
     </ClCompile>
     <ClCompile Include="TestApp6.cpp">
       <Filter>소스 파일\Script</Filter>
+    </ClCompile>
+    <ClCompile Include="Help.cpp">
+      <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Shell/TestApp1.h
+++ b/Shell/TestApp1.h
@@ -9,4 +9,5 @@ public:
 		: ScriptHandler(stringStream, ssdHelper) {}
 
 	bool doScript() override;
+	string usage(void) override { return "testapp1 or FullWriteAndFullReadAndCompare\n"; };
 };

--- a/Shell/TestApp2.h
+++ b/Shell/TestApp2.h
@@ -9,4 +9,5 @@ public:
         : ScriptHandler(stringStream, ssdHelper) {}
 
     bool doScript() override;
+    string usage(void) override { return "testapp2 or Write0to6Repeat30AndWrite0to6AndReadCompare\n"; };
 };

--- a/Shell/TestApp3.h
+++ b/Shell/TestApp3.h
@@ -10,4 +10,5 @@ public:
     {}
 
     bool doScript() override;
+    string usage(void) override { return "testapp3 or FullWriteAndRead99AndCompare\n"; };
 };

--- a/Shell/TestApp4.cpp
+++ b/Shell/TestApp4.cpp
@@ -14,7 +14,7 @@ bool TestApp4::doScript()
 
 		if (outputVector.size() <= 1) continue;
 
-		int lastElem = outputVector.size() - 1;
+		auto lastElem = outputVector.size() - 1;
 		if (outputVector[0] != outputVector[lastElem])
 			return false;
 	}

--- a/Shell/TestApp4.h
+++ b/Shell/TestApp4.h
@@ -12,4 +12,5 @@ public:
     {}
 
     bool doScript() override;
+    string usage(void) override { return "testapp4 or FullReadAndCompare\n"; };
 };

--- a/Shell/TestApp5.h
+++ b/Shell/TestApp5.h
@@ -10,4 +10,5 @@ public:
     {}
 
     bool doScript() override;
+    string usage(void) override { return "testapp5 or Write0Repeat10AndReadCompare\n"; };
 };

--- a/Shell/TestApp6.h
+++ b/Shell/TestApp6.h
@@ -10,4 +10,5 @@ public:
     {}
 
     bool doScript() override;
+    string usage(void) override { return "testapp6 or Write5to10AndWrite8to10AndReadCompare\n"; };
 };

--- a/Shell/Write.cpp
+++ b/Shell/Write.cpp
@@ -17,6 +17,11 @@ Progress Write::doCommand(const vector<string>& args)
 	return Progress::Continue;
 }
 
+string Write::usage() 
+{
+	return "write [LBA] [DATA]\n";
+}
+
 bool Write::isInvalidNumberOfArguments(const std::vector<std::string>& args)
 {
 	return (args.size() != 3);

--- a/Shell/Write.h
+++ b/Shell/Write.h
@@ -16,7 +16,7 @@ public:
 
 	Progress doCommand(const vector<string>& args) override;
 
-	void usage() override {};
+	string usage() override;;
 
 	~Write() {};
 

--- a/Shell/invalid_run_list.lst
+++ b/Shell/invalid_run_list.lst
@@ -1,0 +1,6 @@
+FullWriteAndFullReadAndCompar
+Write0to6Repeat30AndWrite0to6AndReadCompar
+FullWriteAndRead99AndCompar
+FullReadAndCompar
+Write0Repeat10AndReadCompar
+Write5to10AndWrite8to10AndReadCompar

--- a/Shell_Test/CommandFactoryTest.cpp
+++ b/Shell_Test/CommandFactoryTest.cpp
@@ -24,7 +24,6 @@ TEST_F(CommandFactoryTest, ConstructorAndCreate)
 	EXPECT_NE(nullptr, factory.create("fullwrite"));
 	EXPECT_NE(nullptr, factory.create("erase"));
 	EXPECT_NE(nullptr, factory.create("erase_range"));
-	EXPECT_NE(nullptr, factory.create("help"));
 	EXPECT_NE(nullptr, factory.create("exit"));
 	EXPECT_EQ(nullptr, factory.create("INVALID"));
 }

--- a/Shell_Test/EraseRangeTest.cpp
+++ b/Shell_Test/EraseRangeTest.cpp
@@ -12,7 +12,7 @@ public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    EraseRange eraseRange{ redirectedOutput, ssd };
+    EraseRange eraseRange{ m_redirectedOutput, ssd };
 };
 
 TEST_F(EraseRangeTest, DoCommand)

--- a/Shell_Test/EraseRangeTest.cpp
+++ b/Shell_Test/EraseRangeTest.cpp
@@ -2,29 +2,17 @@
 #include <gmock/gmock.h>
 #include "../Shell/EraseRange.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class EraseRangeTest : public Test
+class EraseRangeTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     EraseRange eraseRange{ redirectedOutput, ssd };
-
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
-
-    const string dataZero = "0x00000000";
-
-private:
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(EraseRangeTest, DoCommand)

--- a/Shell_Test/EraseTest.cpp
+++ b/Shell_Test/EraseTest.cpp
@@ -12,7 +12,7 @@ public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    Erase erase{ redirectedOutput, ssd };
+    Erase erase{ m_redirectedOutput, ssd };
 };
 
 TEST_F(EraseTest, DoCommand)

--- a/Shell_Test/EraseTest.cpp
+++ b/Shell_Test/EraseTest.cpp
@@ -2,29 +2,17 @@
 #include <gmock/gmock.h>
 #include "../Shell/Erase.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class EraseTest : public Test
+class EraseTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     Erase erase{ redirectedOutput, ssd };
-
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
-
-    const string dataZero = "0x00000000";
-
-private:
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(EraseTest, DoCommand)

--- a/Shell_Test/EraseTest.cpp
+++ b/Shell_Test/EraseTest.cpp
@@ -17,10 +17,8 @@ public:
 
 TEST_F(EraseTest, DoCommand)
 {
-    vector<string> args;
-    args.push_back("erase");
-    args.push_back("0");
-    args.push_back("100");
+    EXPECT_CALL(ssdExecutableMock, execute("E 0 100")).Times(1);
+    vector<string> args{ "erase", "0", "100"};
     EXPECT_TRUE(erase.isValidArgs(args));
     EXPECT_EQ(Progress::Continue, erase.doCommand(args));
 }

--- a/Shell_Test/ExitTest.cpp
+++ b/Shell_Test/ExitTest.cpp
@@ -19,3 +19,9 @@ TEST_F(ExitTest, DoCommand)
 	vector<string> emptyArgs;
 	EXPECT_EQ(Progress::Done, exit.doCommand(emptyArgs));
 }
+
+TEST_F(ExitTest, InvalidNumberOfArgument)
+{
+	vector<string> args{};
+	EXPECT_FALSE(exit.isValidArgs(args));
+}

--- a/Shell_Test/FullReadTest.cpp
+++ b/Shell_Test/FullReadTest.cpp
@@ -11,13 +11,13 @@ class FullReadTest : public Test, public OutputCapture
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
-    FullRead fullRead{ redirectedOutput, ssd, &read };
+    FullRead fullRead{ m_redirectedOutput, ssd, &read };
 
     const string dataZero = "0x00000000";
 
 private:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    Read read{ redirectedOutput, ssd };
+    Read read{ m_redirectedOutput, ssd };
 };
 
 

--- a/Shell_Test/FullReadTest.cpp
+++ b/Shell_Test/FullReadTest.cpp
@@ -2,30 +2,22 @@
 #include <gmock/gmock.h>
 #include "../Shell/FullRead.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class FullReadTest : public Test
+class FullReadTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     FullRead fullRead{ redirectedOutput, ssd, &read };
 
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
-
     const string dataZero = "0x00000000";
 
 private:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     Read read{ redirectedOutput, ssd };
-    ostringstream redirectedOutput{};
 };
 
 

--- a/Shell_Test/FullReadTest.cpp
+++ b/Shell_Test/FullReadTest.cpp
@@ -23,8 +23,7 @@ private:
 
 TEST_F(FullReadTest, DoCommand)
 {
-    vector<string> args;
-    args.push_back("fullread");
+    vector<string> args{"fullread"};
 
     EXPECT_CALL(ssdExecutableMock, execute(_)).Times(100);
     EXPECT_CALL(ssdResultMock, get())

--- a/Shell_Test/FullReadTest.cpp
+++ b/Shell_Test/FullReadTest.cpp
@@ -33,3 +33,9 @@ TEST_F(FullReadTest, DoCommand)
     EXPECT_TRUE(fullRead.isValidArgs(args));
     EXPECT_EQ(Progress::Continue, fullRead.doCommand(args));
 }
+
+TEST_F(FullReadTest, InvalidNumberOfArgument)
+{
+    vector<string> args{};
+    EXPECT_FALSE(fullRead.isValidArgs(args));
+}

--- a/Shell_Test/FullWriteTest.cpp
+++ b/Shell_Test/FullWriteTest.cpp
@@ -11,11 +11,11 @@ class FullWriteTest : public Test, public OutputCapture
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
-    FullWrite fullWrite{ redirectedOutput, ssd, &write };
+    FullWrite fullWrite{ m_redirectedOutput, ssd, &write };
 
 private:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    Write write{ redirectedOutput, ssd };
+    Write write{ m_redirectedOutput, ssd };
 };
 
 TEST_F(FullWriteTest, DoCommand)

--- a/Shell_Test/FullWriteTest.cpp
+++ b/Shell_Test/FullWriteTest.cpp
@@ -20,16 +20,18 @@ private:
 
 TEST_F(FullWriteTest, DoCommand)
 {
-    vector<string> args;
-    args.push_back("fullwrite");
-    args.push_back("0xABCD1234");
+    vector<string> args{ "fullwrite", "0xABCD1234" };
+
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(100);
 
     EXPECT_TRUE(fullWrite.isValidArgs(args));
     EXPECT_EQ(Progress::Continue, fullWrite.doCommand(args));
 }
 
-TEST_F(FullWriteTest, FullWrite_NotIncludedPrefixException)
+TEST_F(FullWriteTest, NotIncludedPrefixException)
 {
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(0);
+
     string expected = "[WARNING] Prefix '0x' was not included in input data !!!\n";
 
     vector<string> args;
@@ -41,7 +43,7 @@ TEST_F(FullWriteTest, FullWrite_NotIncludedPrefixException)
     EXPECT_THAT(fetchOutput(), Eq(expected));
 }
 
-TEST_F(FullWriteTest, FullWrite_NotAllowedInputDataException)
+TEST_F(FullWriteTest, NotAllowedInputDataException)
 {
     string expected = "[WARNING] Input data has invalid characters !!!\n";
 

--- a/Shell_Test/FullWriteTest.cpp
+++ b/Shell_Test/FullWriteTest.cpp
@@ -2,27 +2,20 @@
 #include <gmock/gmock.h>
 #include "../Shell/FullWrite.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class FullWriteTest : public Test
+class FullWriteTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     FullWrite fullWrite{ redirectedOutput, ssd, &write };
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
 
 private:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     Write write{ redirectedOutput, ssd };
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(FullWriteTest, DoCommand)

--- a/Shell_Test/FullWriteTest.cpp
+++ b/Shell_Test/FullWriteTest.cpp
@@ -55,3 +55,8 @@ TEST_F(FullWriteTest, NotAllowedInputDataException)
     EXPECT_THAT(fetchOutput(), Eq(expected));
 }
 
+TEST_F(FullWriteTest, InvalidNumberOfArgument)
+{
+    vector<string> args{"fullwrite"};
+    EXPECT_FALSE(fullWrite.isValidArgs(args));
+}

--- a/Shell_Test/HelpTest.cpp
+++ b/Shell_Test/HelpTest.cpp
@@ -13,7 +13,8 @@ public:
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     CommandFactory factory{ std::cout, ssd };
-    Help help{m_redirectedOutput, &factory};
+    ScriptFactory scriptFactory{};
+    Help help{m_redirectedOutput, ssd, &factory, &scriptFactory};
 };
 
 TEST_F(HelpTest, DoCommand)
@@ -29,6 +30,12 @@ TEST_F(HelpTest, DoCommand)
         "\terase [START_LBA] [NUMBER_OF_LBA]\n"
         "\terase_range [START_LBA] [END_LBA]\n"
         "\texit\n"
+        "\ttestapp1 or FullWriteAndFullReadAndCompare\n"
+        "\ttestapp2 or Write0to6Repeat30AndWrite0to6AndReadCompare\n"
+        "\ttestapp3 or FullWriteAndRead99AndCompare\n"
+        "\ttestapp4 or FullReadAndCompare\n"
+        "\ttestapp5 or Write0Repeat10AndReadCompare\n"
+        "\ttestapp6 or Write5to10AndWrite8to10AndReadCompare\n"
         "\thelp\n";
     EXPECT_EQ(expectedMessage, commandOutput);
 }

--- a/Shell_Test/HelpTest.cpp
+++ b/Shell_Test/HelpTest.cpp
@@ -13,7 +13,7 @@ public:
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     CommandFactory factory{ std::cout, ssd };
-    Help help{redirectedOutput, ssd, &factory};
+    Help help{m_redirectedOutput, ssd, &factory};
 };
 
 TEST_F(HelpTest, DoCommand)

--- a/Shell_Test/HelpTest.cpp
+++ b/Shell_Test/HelpTest.cpp
@@ -2,10 +2,11 @@
 #include <gmock/gmock.h>
 #include "../Shell/Help.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class HelpTest : public Test
+class HelpTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
@@ -13,17 +14,6 @@ public:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     CommandFactory factory{ std::cout, ssd };
     Help help{redirectedOutput, ssd, &factory};
-
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
-
-private:
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(HelpTest, DoCommand)

--- a/Shell_Test/HelpTest.cpp
+++ b/Shell_Test/HelpTest.cpp
@@ -13,7 +13,7 @@ public:
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     CommandFactory factory{ std::cout, ssd };
-    Help help{m_redirectedOutput, ssd, &factory};
+    Help help{m_redirectedOutput, &factory};
 };
 
 TEST_F(HelpTest, DoCommand)
@@ -28,7 +28,7 @@ TEST_F(HelpTest, DoCommand)
         "\tfullwrite [DATA]\n"
         "\terase [START_LBA] [NUMBER_OF_LBA]\n"
         "\terase_range [START_LBA] [END_LBA]\n"
-        "\thelp\n"
-        "\texit\n";
+        "\texit\n"
+        "\thelp\n";
     EXPECT_EQ(expectedMessage, commandOutput);
 }

--- a/Shell_Test/HelpTest.cpp
+++ b/Shell_Test/HelpTest.cpp
@@ -8,19 +8,11 @@ using namespace testing;
 class HelpTest : public Test
 {
 public:
-    class TestableHelp : public Help
-    {
-    public:
-        NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
-        NiceMock<SsdResultMock> ssdResultMock{};
-        SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-        TestableHelp(ostream& _out) : Help(_out, ssd) {}
-        const string& helpMessage(void)
-        {
-            return m_helpMessage;
-        }
-    };
-    TestableHelp help{ redirectedOutput };
+    NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
+    NiceMock<SsdResultMock> ssdResultMock{};
+    SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
+    CommandFactory factory{ std::cout, ssd };
+    Help help{redirectedOutput, ssd, &factory};
 
     string fetchOutput(void)
     {
@@ -39,6 +31,14 @@ TEST_F(HelpTest, DoCommand)
 	vector<string> emptyArgs;
 	EXPECT_EQ(Progress::Continue, help.doCommand(emptyArgs));
     auto commandOutput = fetchOutput();
-
-    EXPECT_EQ(help.helpMessage(), commandOutput);
+    const string expectedMessage = "Help:\n"
+        "\tread [LBA]\n"
+        "\twrite [LBA] [DATA]\n"
+        "\tfullread\n"
+        "\tfullwrite [DATA]\n"
+        "\terase [START_LBA] [NUMBER_OF_LBA]\n"
+        "\terase_range [START_LBA] [END_LBA]\n"
+        "\thelp\n"
+        "\texit\n";
+    EXPECT_EQ(expectedMessage, commandOutput);
 }

--- a/Shell_Test/OutputCapture.h
+++ b/Shell_Test/OutputCapture.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+
+class OutputCapture
+{
+protected:
+    std::string fetchOutput(void)
+    {
+        auto fetchedString = redirectedOutput.str();
+        redirectedOutput.str("");
+        redirectedOutput.clear();
+        return fetchedString;
+    }
+    std::ostringstream redirectedOutput{};
+};

--- a/Shell_Test/OutputCapture.h
+++ b/Shell_Test/OutputCapture.h
@@ -8,10 +8,10 @@ class OutputCapture
 protected:
     std::string fetchOutput(void)
     {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
+        auto fetchedString = m_redirectedOutput.str();
+        m_redirectedOutput.str("");
+        m_redirectedOutput.clear();
         return fetchedString;
     }
-    std::ostringstream redirectedOutput{};
+    std::ostringstream m_redirectedOutput{};
 };

--- a/Shell_Test/ReadTest.cpp
+++ b/Shell_Test/ReadTest.cpp
@@ -17,14 +17,6 @@ public:
     const string dataZero = "0x00000000";
 };
 
-TEST_F(ReadTest, DoCommand)
-{
-    vector<string> args;
-    args.push_back("read");
-    args.push_back("0");
-    EXPECT_EQ(Progress::Continue, read.doCommand(args));
-}
-
 TEST_F(ReadTest, OutOfLbaRead)
 {
     static const string INVALID_LBA = "100";
@@ -36,16 +28,15 @@ TEST_F(ReadTest, OutOfLbaRead)
 
 TEST_F(ReadTest, ReadSuccess)
 {
-    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(100);
     EXPECT_CALL(ssdResultMock, get())
         .Times(100)
         .WillRepeatedly(Return(dataZero));
 
     for (int lba = 0; lba < 100; lba++)
     {
-        vector<string> args;
-        args.push_back("read");
-        args.push_back(to_string(lba));
+        string lbaString = to_string(lba);
+        EXPECT_CALL(ssdExecutableMock, execute("R " + lbaString )).Times(1);
+        vector<string> args{ "read", lbaString };
         read.doCommand(args);
         EXPECT_EQ(dataZero + "\n", fetchOutput());
     }

--- a/Shell_Test/ReadTest.cpp
+++ b/Shell_Test/ReadTest.cpp
@@ -2,10 +2,11 @@
 #include <gmock/gmock.h>
 #include "../Shell/Read.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class ReadTest : public Test
+class ReadTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
@@ -13,18 +14,7 @@ public:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     Read read{ redirectedOutput, ssd };
 
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
-
     const string dataZero = "0x00000000";
-
-private:
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(ReadTest, DoCommand)

--- a/Shell_Test/ReadTest.cpp
+++ b/Shell_Test/ReadTest.cpp
@@ -12,7 +12,7 @@ public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    Read read{ redirectedOutput, ssd };
+    Read read{ m_redirectedOutput, ssd };
 
     const string dataZero = "0x00000000";
 };

--- a/Shell_Test/ReadTest.cpp
+++ b/Shell_Test/ReadTest.cpp
@@ -41,3 +41,9 @@ TEST_F(ReadTest, ReadSuccess)
         EXPECT_EQ(dataZero + "\n", fetchOutput());
     }
 }
+
+TEST_F(ReadTest, InvalidNumberOfArgument)
+{
+    vector<string> args{ "read" };
+    EXPECT_FALSE(read.isValidArgs(args));
+}

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -174,12 +174,34 @@ TEST_F(ShellTestFixture, RunAndInvalidArguments)
 TEST_F(ShellTestFixture, RunAndTestApp1)
 {
     EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
-    EXPECT_CALL(ssdResultMock, get()).Times(100).WillRepeatedly(Return("0xDEADC0DE"));
+    EXPECT_CALL(ssdResultMock, get())
+        .Times(100)
+        .WillRepeatedly(Return("0xDEADC0DE"));
     string inputString = "testapp1 A\n"
         "exit\n";
 
     const string expectedMessage = "shell> "
         "testapp1 Pass!\n\n"
+        "shell> " "Exit from Shell\n";
+
+    runAndExpect(inputString, expectedMessage);
+}
+
+TEST_F(ShellTestFixture, RunAndTestApps)
+{
+    EXPECT_CALL(ssdResultMock, get()).WillRepeatedly(Return("0xDEADC0DE"));
+    string inputString =
+        "testapp3 A\n"
+        "testapp4 A\n"
+        "testapp5 A\n"
+        "exit\n";
+
+    const string expectedMessage = "shell> "
+        "testapp3 Pass!\n\n"
+        "shell> "
+        "testapp4 Pass!\n\n"
+        "shell> "
+        "testapp5 Pass!\n\n"
         "shell> " "Exit from Shell\n";
 
     runAndExpect(inputString, expectedMessage);

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -119,8 +119,8 @@ TEST_F(ShellTestFixture, RunAndHelp)
         "\tfullwrite [DATA]\n"
         "\terase [START_LBA] [NUMBER_OF_LBA]\n"
         "\terase_range [START_LBA] [END_LBA]\n"
-        "\thelp\n"
         "\texit\n"
+        "\thelp\n"
         "shell> " "Exit from Shell\n";
 
     runAndExpect(inputString, expectedMessage);

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -216,3 +216,18 @@ TEST_F(ShellTestFixture, RunAndTestApps)
 
     runAndExpect(inputString, expectedMessage);
 }
+
+TEST_F(ShellTestFixture, RunnerSucceed)
+{
+    shell.runRunner("run_list.lst");
+}
+
+TEST_F(ShellTestFixture, RunnerWithInvalidFileName)
+{
+    shell.runRunner("invalid.file");
+}
+
+TEST_F(ShellTestFixture, RunnerWithInvalidRunList)
+{
+    shell.runRunner("invalid_run_list.lst");
+}

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -125,3 +125,25 @@ TEST_F(ShellTestFixture, RunAndHelp)
 
     runAndExpect(inputString, expectedMessage);
 }
+
+TEST_F(ShellTestFixture, RunAndInvalidCommand)
+{
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(0);
+    EXPECT_CALL(ssdResultMock, get()).Times(0);
+    string inputString = "reda 3\n"
+        "\n"
+        "      \n"
+        " help\n"
+        "exit\n";
+
+    const string expectedMessage = "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> "
+        "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> " "Exit from Shell\n";
+
+    runAndExpect(inputString, expectedMessage);
+}

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -6,11 +6,12 @@
 #include "../Shell/Shell.cpp"
 #include "../Shell/Logger.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace std;
 using namespace testing;
 
-class ShellTestFixture : public Test
+class ShellTestFixture : public Test, public OutputCapture
 {
 protected:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
@@ -18,22 +19,7 @@ protected:
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     Shell shell{ssd, redirectedOutput};
 
-    static constexpr int INVALID_LBA = 100;
-    static constexpr int VALID_LBA = 99;
     const string dataZero = "0x00000000";
-    const string testData = "0xDEADC0DE";
-
-    void SetUp(void) override
-    {
-    }
-
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
 
     void runAndExpect(const string& input, const string& expected)
     {
@@ -41,9 +27,6 @@ protected:
         shell.run(ss);
         EXPECT_EQ(expected, fetchOutput());
     }
-
-private:
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(ShellTestFixture, RunAndExit)

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -170,3 +170,17 @@ TEST_F(ShellTestFixture, RunAndInvalidArguments)
 
     runAndExpect(inputString, expectedMessage);
 }
+
+TEST_F(ShellTestFixture, RunAndTestApp1)
+{
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(200);
+    EXPECT_CALL(ssdResultMock, get()).Times(100).WillRepeatedly(Return("0xDEADC0DE"));
+    string inputString = "testapp1 A\n"
+        "exit\n";
+
+    const string expectedMessage = "shell> "
+        "testapp1 Pass!\n\n"
+        "shell> " "Exit from Shell\n";
+
+    runAndExpect(inputString, expectedMessage);
+}

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -35,7 +35,7 @@ protected:
         return fetchedString;
     }
 
-    void runAndExpect(const string& input, string& expected)
+    void runAndExpect(const string& input, const string& expected)
     {
         auto ss = istringstream(input);
         shell.run(ss);
@@ -128,13 +128,17 @@ TEST_F(ShellTestFixture, RunAndHelp)
     string inputString = "help\n"
         "exit\n";
 
-    string expected = "shell> "
+    const string expectedMessage = "shell> "
         "Help:\n"
         "\tread [LBA]\n"
         "\twrite [LBA] [DATA]\n"
         "\tfullread\n"
         "\tfullwrite [DATA]\n"
+        "\terase [START_LBA] [NUMBER_OF_LBA]\n"
+        "\terase_range [START_LBA] [END_LBA]\n"
+        "\thelp\n"
+        "\texit\n"
         "shell> " "Exit from Shell\n";
 
-    runAndExpect(inputString, expected);
+    runAndExpect(inputString, expectedMessage);
 }

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -17,7 +17,7 @@ protected:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    Shell shell{ssd, redirectedOutput};
+    Shell shell{ssd, m_redirectedOutput};
 
     const string dataZero = "0x00000000";
 

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -120,6 +120,12 @@ TEST_F(ShellTestFixture, RunAndHelp)
         "\terase [START_LBA] [NUMBER_OF_LBA]\n"
         "\terase_range [START_LBA] [END_LBA]\n"
         "\texit\n"
+        "\ttestapp1 or FullWriteAndFullReadAndCompare\n"
+        "\ttestapp2 or Write0to6Repeat30AndWrite0to6AndReadCompare\n"
+        "\ttestapp3 or FullWriteAndRead99AndCompare\n"
+        "\ttestapp4 or FullReadAndCompare\n"
+        "\ttestapp5 or Write0Repeat10AndReadCompare\n"
+        "\ttestapp6 or Write5to10AndWrite8to10AndReadCompare\n"
         "\thelp\n"
         "shell> " "Exit from Shell\n";
 

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -166,12 +166,16 @@ TEST_F(ShellTestFixture, RunAndInvalidArguments)
 
     const string expectedMessage = "shell> "
         "\nINVALID COMMAND\n"
+        "read [LBA]\n"
         "shell> "
         "\nINVALID COMMAND\n"
+        "write [LBA] [DATA]\n"
         "shell> "
         "\nINVALID COMMAND\n"
+        "erase [START_LBA] [NUMBER_OF_LBA]\n"
         "shell> "
         "\nINVALID COMMAND\n"
+        "erase_range [START_LBA] [END_LBA]\n"
         "shell> " "Exit from Shell\n";
 
     runAndExpect(inputString, expectedMessage);

--- a/Shell_Test/ShellTest.cpp
+++ b/Shell_Test/ShellTest.cpp
@@ -147,3 +147,26 @@ TEST_F(ShellTestFixture, RunAndInvalidCommand)
 
     runAndExpect(inputString, expectedMessage);
 }
+
+TEST_F(ShellTestFixture, RunAndInvalidArguments)
+{
+    EXPECT_CALL(ssdExecutableMock, execute(_)).Times(0);
+    EXPECT_CALL(ssdResultMock, get()).Times(0);
+    string inputString = "read A\n"
+        "write abcd1234\n"
+        "erase 1 100\n"
+        "erase_range 100 1\n"
+        "exit\n";
+
+    const string expectedMessage = "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> "
+        "\nINVALID COMMAND\n"
+        "shell> " "Exit from Shell\n";
+
+    runAndExpect(inputString, expectedMessage);
+}

--- a/Shell_Test/Shell_Test.vcxproj
+++ b/Shell_Test/Shell_Test.vcxproj
@@ -128,6 +128,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="OutputCapture.h" />
     <ClInclude Include="ScriptTestFixture.h" />
     <ClInclude Include="SsdMock.h" />
   </ItemGroup>

--- a/Shell_Test/Shell_Test.vcxproj.filters
+++ b/Shell_Test/Shell_Test.vcxproj.filters
@@ -34,9 +34,6 @@
     <ClCompile Include="EraseRangeTest.cpp">
       <Filter>소스 파일\CommandTest</Filter>
     </ClCompile>
-    <ClCompile Include="ScriptTestFixture.cpp">
-      <Filter>소스 파일\ScriptTest</Filter>
-    </ClCompile>
     <ClCompile Include="TestApp1Test.cpp">
       <Filter>소스 파일\ScriptTest</Filter>
     </ClCompile>
@@ -75,6 +72,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SsdMock.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="ScriptTestFixture.h" />
+    <ClInclude Include="OutputCapture.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Shell_Test/Shell_Test.vcxproj.filters
+++ b/Shell_Test/Shell_Test.vcxproj.filters
@@ -22,9 +22,6 @@
     <ClCompile Include="FullWriteTest.cpp">
       <Filter>소스 파일\CommandTest</Filter>
     </ClCompile>
-    <ClCompile Include="HelpTest.cpp">
-      <Filter>소스 파일\CommandTest</Filter>
-    </ClCompile>
     <ClCompile Include="ReadTest.cpp">
       <Filter>소스 파일\CommandTest</Filter>
     </ClCompile>
@@ -51,6 +48,9 @@
     </ClCompile>
     <ClCompile Include="TestApp6Test.cpp">
       <Filter>소스 파일\ScriptTest</Filter>
+    </ClCompile>
+    <ClCompile Include="HelpTest.cpp">
+      <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Shell_Test/WriteTest.cpp
+++ b/Shell_Test/WriteTest.cpp
@@ -2,24 +2,17 @@
 #include <gmock/gmock.h>
 #include "../Shell/Write.cpp"
 #include "SsdMock.h"
+#include "OutputCapture.h"
 
 using namespace testing;
 
-class WriteTest : public Test
+class WriteTest : public Test, public OutputCapture
 {
 public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
     Write write{ redirectedOutput, ssd };
-
-    string fetchOutput(void)
-    {
-        auto fetchedString = redirectedOutput.str();
-        redirectedOutput.str("");
-        redirectedOutput.clear();
-        return fetchedString;
-    }
 
     void VerifyDataAndExpect(string input, string expected)
     {
@@ -34,9 +27,6 @@ public:
 
     const string dataZero = "0x00000000";
     const string VALID_LBA = "99";
-
-private:
-    ostringstream redirectedOutput{};
 };
 
 TEST_F(WriteTest, DoCommand)

--- a/Shell_Test/WriteTest.cpp
+++ b/Shell_Test/WriteTest.cpp
@@ -52,3 +52,9 @@ TEST_F(WriteTest, InvalidDataFormatWrite)
     VerifyDataAndExpect("abcd123456", "[WARNING] Prefix '0x' was not included in input data !!!\n");
     VerifyDataAndExpect("0xabcd1234", "[WARNING] Input data has invalid characters !!!\n");
 }
+
+TEST_F(WriteTest, InvalidNumberOfArgument)
+{
+    vector<string> args{ "write", "0" };
+    EXPECT_FALSE(write.isValidArgs(args));
+}

--- a/Shell_Test/WriteTest.cpp
+++ b/Shell_Test/WriteTest.cpp
@@ -12,7 +12,7 @@ public:
     NiceMock<SsdExcutalbeMock> ssdExecutableMock{};
     NiceMock<SsdResultMock> ssdResultMock{};
     SsdHelper ssd{ &ssdExecutableMock, &ssdResultMock };
-    Write write{ redirectedOutput, ssd };
+    Write write{ m_redirectedOutput, ssd };
 
     void VerifyDataAndExpect(string input, string expected)
     {


### PR DESCRIPTION
 - shell 에서 help 출력할 때 정해진 메시지가 아니라, factory에 등록된 handler들의 usage를 호출하여 help message를 빌드할 수 있도록 하였습니다.
 - TC 코드를 보강하여 test coverage를 높였습니다.
 - TC 코드에서 자주 사용되던 redirectedOutput 변수와 fetchOutput 함수를 OutputCapture class로 추출하여 중복 코드를 삭제하였습니다.